### PR TITLE
Replaced angle brackets in ALL_IN_ONE.md like in template_stuff.md to make the template <T> parts visible.

### DIFF
--- a/ALL_IN_ONE.md
+++ b/ALL_IN_ONE.md
@@ -537,31 +537,29 @@ C++17
 <tr>
 <td  valign="top">
 <pre lang="cpp">
-{
-   auto sum() { return 0; }
-   
-   template <typename T>
-   auto sum(T&& t) { return t; }
-   
-   template <typename T, typename... Rest>
-   auto sum(T&& t, Rest&&... r) {
-      return t + sum(std::forward<Rest>(r)...);
-   }
+auto sum() { return 0; }
+
+template &lt;typename T&gt;
+auto sum(T&amp;&amp; t) { return t; }
+
+template &lt;typename T, typename... Rest&gt;
+auto sum(T&amp;&amp; t, Rest&amp;&amp;... r) {
+   return t + sum(std::forward&lt;Rest&gt;(r)...);
 }
 </pre>
 </td>
 <td  valign="top">
 <pre lang="cpp">
-{
 
 
 
 
 
-   template <typename... Args>
-   auto sum(Args&&... args) {
-      return (args + ... + 0);
-   }
+
+
+template &lt;typename... Args&gt;
+auto sum(Args&amp;&amp;... args) {
+   return (args + ... + 0);
 }
 </pre>
 </td>


### PR DESCRIPTION


In https://github.com/tvaneerd/cpp17_in_TTs/blob/master/ALL_IN_ONE.md#fold-expressions at least on the C++14 side it shows 

```
template 
   auto sum(T&& t) { return t; }
```
when it should be
```
template <class T>
   auto sum(T&& t) { return t; }
```
Same for the example below and the C++17 side.