### PR TITLE
Extern not necessary in at the definition

### DIFF
--- a/small_stuff.md
+++ b/small_stuff.md
@@ -92,7 +92,7 @@ C++17
 extern int foo;
 
 // foo.cpp
-extern int foo = 10;
+int foo = 10;
 </pre>
 </td>
 <td  valign="top">


### PR DESCRIPTION
Removes the unnecessary `extern` from the definition in the source file.

