### PR TITLE
Removed extraneous params from struct destructurings

### DIFF
--- a/ALL_IN_ONE.md
+++ b/ALL_IN_ONE.md
@@ -363,7 +363,7 @@ C++17
    Foo stuff();
      
      
-   auto [ i, s ] = stuff();
+   auto [ i, s ] = stuff;
 
 
    use(s, ++i);
@@ -379,7 +379,7 @@ C++17
    
    Foo stuff();
    
-   Foo __tmp = stuff();
+   Foo __tmp = stuff;
    auto &amp; i = __tmp.x;
    auto &amp; s = __tmp.str;
 
@@ -417,7 +417,7 @@ C++17
    
    Foo stuff();
 
-   auto [ i, s ] = stuff();
+   auto [ i, s ] = stuff;
 
    use(s, ++i);
 </pre>


### PR DESCRIPTION
I'm pretty sure they were wrong here. Not sure if the object definitions will trigger MVP as well - maybe they should be initialized with `{}`?